### PR TITLE
Ballot-polling risk_levels, multiround sample size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.pyc
 .*swp
 db.sqlite3*
+.hypothesis
+.cache
+.ipynb_checkpoints
+.idea

--- a/audit_cvrs/TODO
+++ b/audit_cvrs/TODO
@@ -1,0 +1,5 @@
+rlacalc ballot-polling branch:
+ does it work with python 3?
+  with amazon lambda?
+ Add a test for OverflowError
+ add smart_boolean support to make web form make more sense(?)

--- a/audit_cvrs/parse_dominion_cvrs.py
+++ b/audit_cvrs/parse_dominion_cvrs.py
@@ -237,7 +237,12 @@ def parse():
 
     import pandas as pd
     df = pd.DataFrame.from_dict(contestBallotsByBatchManager, orient='index').transpose()
+
+    # Print description statistics for each contest of number of ballots by batch
+    # FIXME: assumes a single tabulator. need to combine tabulator and batch ids....
+
     # hmmm - how to add the contest name (Description) to the mix? df['Contest'] = apply(
+    # Use option_context to print all rows and columns out, no maximums
     with pd.option_context('display.max_rows', None, 'display.max_columns', None):
         print df.describe().transpose()
 

--- a/audit_cvrs/rlacalc.py
+++ b/audit_cvrs/rlacalc.py
@@ -834,7 +834,7 @@ def main(parser):
     if opts.polling:
         if opts.level:
             risk_level = ballot_polling_risk_level(opts.winnervotes, opts.loservotes, opts.winnersamples, opts.losersamples)
-            print("%.4f" % risk_level)
+            print("Risk level: %.4g" % risk_level)
         else:
             samplesize = findAsn(opts.alpha / 100.0, opts.margin / 100.0, opts.risk_level / 100.0)
             print("Sample size = %d for ballot polling, margin %g%%, risk %g%%" % (samplesize, opts.margin, opts.alpha))

--- a/audit_cvrs/test.py
+++ b/audit_cvrs/test.py
@@ -1,0 +1,49 @@
+"""Test rlacalc
+Use hypothesis testing framework:
+ https://hypothesis.readthedocs.io/en/latest/quickstart.html
+
+TODO:
+ see what's up with really small margins, e.g.
+ falsified: test_nmin(alpha=1e-06, gamma=1.001, margin=1e-10, o1=0, o2=0, u1=0, u2=0)
+
+"""
+
+import sys
+# TODO: get pytest working without this and without python3 -m pytest
+#sys.path.insert(0, '/home/neal/py/projects/audit_cvrs/audit_cvrs')
+
+import logging
+logging.basicConfig(filename='hypothesis-test.log', level=logging.DEBUG)
+logging.debug("pytest path: %s" % sys.path)
+
+import rlacalc
+
+# print("raw nmin test: %s" % rlacalc.nmin(0.05, 1.03905, 0.02, 0, 0, 0, 0))
+
+from hypothesis import given, settings, Verbosity, example, assume
+
+import hypothesis.strategies as st
+
+@given(st.floats(10**-6, 1.01),
+       st.floats(1.01, 10.0),
+       st.floats(10**-6, 1.01),
+       st.integers(0, 100), st.integers(0, 100), st.integers(0, 100), st.integers(0, 100))
+@settings(max_examples=1000)
+@example(0.05, 1.03905, 0.02, 1, 1, 1, 1)
+def test_nmin(alpha, gamma, margin, o1, o2, u1, u2):
+
+    assume(0.0 < alpha <= 1.0)
+    assume(0.0 < margin <= 1.0)
+    assume(gamma > 1.0)
+    assume(not (o1 < 0  or  o2 < 0  or u1 < 0  or u2 < 0))
+
+    samples = rlacalc.nmin(alpha, gamma, margin, o1, o2, u1, u2)
+    assert samples >= 0
+    assert rlacalc.KM_P_value(samples, gamma, margin, o1, o2, u1, u2) <= alpha, "Didn't meet alpha; samples = %d" % samples
+
+"""
+    perhaps useful?
+    try: ...nmin...
+    except OverflowError:
+        assume(False)
+"""


### PR DESCRIPTION
Support --risk_level for --polling audits: Add ballot_polling_risk_level()
Support ongoing estimates of remaining work via a risk_level parameter to findAsn()

Note:
 "-R" option now used for --risk_level, not --rawrates.
 "-l" option now used for --losersamples, not --level

For use with [Ballot-polling workarounds by nealmcb · Pull Request #913 · FreeAndFair/ColoradoRLA](https://github.com/FreeAndFair/ColoradoRLA/pull/913)